### PR TITLE
Add UI scale slider for Dashboard buttons section

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,6 +27,7 @@ export default function App() {
   const theme = useAppStore((s) => s.theme)
   const themeOverrides = useAppStore((s) => s.themeOverrides)
   const customThemes = useAppStore((s) => s.customThemes)
+  const uiScale = useAppStore((s) => s.uiScale)
 
   useEffect(() => {
     const ct = customThemes.find((t) => t.id === theme)
@@ -43,6 +44,10 @@ export default function App() {
       }
     }
   }, [theme, themeOverrides])
+
+  useEffect(() => {
+    document.documentElement.style.setProperty('--ui-scale', uiScale)
+  }, [uiScale])
 
   return (
     <Layout>

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import Sidebar from './Sidebar.jsx'
 import ThemeToggle from './ThemeToggle.jsx'
+import ScaleSlider from './ScaleSlider.jsx'
 
 export default function Layout({ children }) {
   const location = useLocation()
@@ -23,6 +24,7 @@ export default function Layout({ children }) {
         <header className="layout-header">
           <h1 className="layout-header-title">{pageTitle()}</h1>
           <div className="layout-header-actions">
+            <ScaleSlider />
             <ThemeToggle />
           </div>
         </header>

--- a/src/components/ScaleSlider.jsx
+++ b/src/components/ScaleSlider.jsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { Minimize2 } from 'lucide-react'
+import useAppStore from '../store/useAppStore.js'
+
+export default function ScaleSlider() {
+  const uiScale = useAppStore((s) => s.uiScale)
+  const setUIScale = useAppStore((s) => s.setUIScale)
+
+  const handleChange = (e) => {
+    const value = parseFloat(e.target.value)
+    setUIScale(value)
+    document.documentElement.style.setProperty('--ui-scale', value)
+  }
+
+  const percentage = Math.round(uiScale * 100)
+
+  return (
+    <div className="scale-slider-wrap">
+      <button
+        className="btn btn-ghost btn-sm"
+        title="UI Scale"
+        aria-label="UI Scale control"
+      >
+        <Minimize2 size={18} />
+      </button>
+      <input
+        type="range"
+        min="0.5"
+        max="1.5"
+        step="0.1"
+        value={uiScale}
+        onChange={handleChange}
+        className="scale-slider-input"
+        title={`UI Scale: ${percentage}%`}
+      />
+      <span className="scale-slider-label">{percentage}%</span>
+    </div>
+  )
+}

--- a/src/store/useAppStore.js
+++ b/src/store/useAppStore.js
@@ -254,6 +254,9 @@ A quick reference for the most frequently encountered helpdesk issues.
 const useAppStore = create(
   persist(
     (set, get) => ({
+      // UI Scale
+      uiScale: 1,
+      setUIScale: (scale) => set({ uiScale: Math.max(0.5, Math.min(1.5, scale)) }),
       // Theme
       theme: 'light',
       lastLightTheme: 'light',
@@ -424,6 +427,7 @@ const useAppStore = create(
         }
       },
       resetToDefaults: () => set({
+        uiScale: 1,
         theme: 'light',
         lastLightTheme: 'light',
         lastDarkTheme: 'dark',
@@ -439,6 +443,7 @@ const useAppStore = create(
     {
       name: 'hdesk_wiki_store',
       partialize: (state) => ({
+        uiScale: state.uiScale,
         theme: state.theme,
         lastLightTheme: state.lastLightTheme,
         lastDarkTheme: state.lastDarkTheme,
@@ -455,6 +460,8 @@ const useAppStore = create(
           const theme = state.theme || 'light'
           const ct = (state.customThemes || []).find((t) => t.id === theme)
           document.documentElement.setAttribute('data-theme', ct ? ct.baseTheme : theme)
+          const scale = state.uiScale || 1
+          document.documentElement.style.setProperty('--ui-scale', scale)
         }
       },
     }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -917,6 +917,103 @@ input, textarea, select {
 }
 
 /* ══════════════════════════════════════════════════════════
+   UI SCALE CONTROLS
+══════════════════════════════════════════════════════════ */
+:root {
+  --ui-scale: 1;
+}
+
+/* Scale slider in header */
+.scale-slider-wrap {
+  display: flex;
+  align-items: center;
+  gap: calc(6px * var(--ui-scale));
+}
+
+.scale-slider-input {
+  width: 80px;
+  height: 4px;
+  border-radius: 2px;
+  appearance: none;
+  background: var(--color-border);
+  outline: none;
+  cursor: pointer;
+}
+
+.scale-slider-input::-webkit-slider-thumb {
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.scale-slider-input::-webkit-slider-thumb:hover {
+  background: var(--color-primary-dark);
+}
+
+.scale-slider-input::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  border: none;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.scale-slider-input::-moz-range-thumb:hover {
+  background: var(--color-primary-dark);
+}
+
+.scale-slider-label {
+  font-size: 12px;
+  min-width: 35px;
+  text-align: right;
+  color: var(--color-text-muted);
+  font-weight: 500;
+}
+
+/* Tool grid scaling - prioritize gaps first, then sizes */
+.tool-grid-container {
+  gap: calc(28px * max(0.6, var(--ui-scale)));
+}
+
+.tool-category-section {
+  gap: calc(12px * max(0.6, var(--ui-scale)));
+}
+
+.tool-cards-grid {
+  gap: calc(12px * max(0.6, var(--ui-scale)));
+  grid-template-columns: repeat(auto-fill, minmax(calc(180px * var(--ui-scale)), 1fr));
+}
+
+.tool-card {
+  min-height: calc(110px * var(--ui-scale));
+  padding: calc(12px * var(--ui-scale));
+}
+
+.tool-card-icon {
+  width: calc(44px * var(--ui-scale));
+  height: calc(44px * var(--ui-scale));
+}
+
+.tool-card-name {
+  font-size: calc(13px * var(--ui-scale));
+}
+
+.tool-card-desc {
+  font-size: calc(11px * var(--ui-scale));
+}
+
+.tool-add-card {
+  min-height: calc(110px * var(--ui-scale));
+  padding: calc(12px * var(--ui-scale));
+}
+
+/* ══════════════════════════════════════════════════════════
    QRG PANEL
 ══════════════════════════════════════════════════════════ */
 .qrg-panel {


### PR DESCRIPTION
- Create new ScaleSlider component with range input (0.5x to 1.5x)
- Add uiScale state to Zustand store with persistence
- Position slider next to dark/light theme toggle in header
- Implement CSS scaling with priority for reducing gaps first, then button sizes
- Scale gaps on tool grid, categories, and cards based on --ui-scale variable
- Scale button dimensions and font sizes proportionally

https://claude.ai/code/session_01KFq9TQV9Ag76Srto3jQJCL