### PR TITLE
UI improvements: header styling and row button layout

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -316,7 +316,7 @@ input, textarea, select {
   justify-content: space-between;
   padding: 0 24px;
   height: var(--header-height);
-  background: var(--color-surface);
+  background: var(--color-sidebar);
   border-bottom: 1px solid var(--color-border);
   flex-shrink: 0;
   transition: background var(--transition-slow), border-color var(--transition-slow);
@@ -940,6 +940,14 @@ input, textarea, select {
   padding: 12px;
   background: var(--color-bg);
   border-bottom: 1px solid var(--color-border);
+  flex-wrap: nowrap;
+}
+
+.selfadmin-row-header > div {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: nowrap;
 }
 
 .selfadmin-row-title {


### PR DESCRIPTION
Header:
- Change header background color to match sidebar (--color-sidebar)
- Header and sidebar now have cohesive visual design
- Header height remains at 64px, matching sidebar brand

Self Admin:
- Add flex-wrap: nowrap to row header
- Ensure row buttons stay horizontal and don't stack
- Add proper flex styling to button container

https://claude.ai/code/session_01KFq9TQV9Ag76Srto3jQJCL