### PR TITLE
Remove debug logging and add image upload to documents

### DIFF
--- a/src/components/WikiEditor.jsx
+++ b/src/components/WikiEditor.jsx
@@ -15,7 +15,7 @@ import {
   Bold, Italic, Code, Strikethrough,
   Heading1, Heading2, Heading3,
   List, ListOrdered, Quote, Minus, Table as TableIcon,
-  Link2, Palette,
+  Link2, Palette, Image as ImageIcon,
 } from 'lucide-react'
 
 marked.setOptions({ breaks: true, gfm: true })
@@ -186,6 +186,7 @@ export default function WikiEditor({ value = '', onChange, placeholder = 'Start 
   const [showColorPicker, setShowColorPicker] = useState(false)
   const tableButtonRef = useRef()
   const colorButtonRef = useRef()
+  const imageInputRef = useRef()
 
   const editor = useEditor({
     extensions: [
@@ -248,6 +249,21 @@ export default function WikiEditor({ value = '', onChange, placeholder = 'Start 
   const handleInsertTable = (rows, cols) => {
     editor.chain().focus().insertTable({ rows, cols, withHeaderRow: true }).run()
     setShowTablePicker(false)
+  }
+
+  const handleImageUpload = (e) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    const reader = new FileReader()
+    reader.onload = (ev) => {
+      const dataUrl = ev.target?.result
+      if (dataUrl) {
+        editor.chain().focus().insertContent(`<img src="${dataUrl}" style="max-width: 100%; height: auto;" alt="Image" />`).run()
+      }
+    }
+    reader.readAsDataURL(file)
+    e.target.value = '' // Reset input
   }
 
   return (
@@ -313,7 +329,7 @@ export default function WikiEditor({ value = '', onChange, placeholder = 'Start 
             )}
           </div>
           <div className="wiki-toolbar-divider" />
-          {/* Link */}
+          {/* Link & Image */}
           <div className="wiki-toolbar-group">
             <ToolbarButton
               onClick={() => {
@@ -336,6 +352,19 @@ export default function WikiEditor({ value = '', onChange, placeholder = 'Start 
             >
               <Link2 size={15} />
             </ToolbarButton>
+            <ToolbarButton
+              onClick={() => imageInputRef.current?.click()}
+              title="Insert Image"
+            >
+              <ImageIcon size={15} />
+            </ToolbarButton>
+            <input
+              ref={imageInputRef}
+              type="file"
+              accept="image/*"
+              onChange={handleImageUpload}
+              style={{ display: 'none' }}
+            />
           </div>
           <div className="wiki-toolbar-divider" />
           {/* Text colour — 13-colour palette */}

--- a/src/lib/StorageManager.js
+++ b/src/lib/StorageManager.js
@@ -174,16 +174,7 @@ class StorageManager {
     if (!book) return null
 
     const chapters = await this.listChapters(bookId)
-    const chapter = chapters.find(c => c.id === chapterId) || null
-
-    if (chapter) {
-      console.log(`[StorageManager] Retrieved chapter: ${chapterId}`, {
-        hasContent: !!chapter.content,
-        contentLength: chapter.content?.length || 0,
-      })
-    }
-
-    return chapter
+    return chapters.find(c => c.id === chapterId) || null
   }
 
   /**
@@ -244,14 +235,8 @@ class StorageManager {
     const chapter = await this.getChapter(bookId, chapterId)
     if (!chapter) throw new Error(`Chapter not found: ${chapterId}`)
 
-    console.log(`[StorageManager] Reading content for chapter: ${chapterId}`, {
-      hasContent: !!chapter.content,
-      contentLength: chapter.content?.length || 0,
-    })
-
     // Primary: content stored in chapter object
     if (chapter.content) {
-      console.log(`[StorageManager] Found content in chapter object: ${chapterId}`)
       return chapter.content
     }
 
@@ -259,15 +244,11 @@ class StorageManager {
     try {
       const notesPath = `${chapter.path}/Notes.md`
       const content = await this._readFile(notesPath)
-      if (content) {
-        console.log(`[StorageManager] Found content in files store: ${chapterId}`)
-        return content
-      }
+      if (content) return content
     } catch (err) {
-      console.warn('[StorageManager] Failed to read from files store:', err)
+      // Silently fail, will return empty string
     }
 
-    console.log(`[StorageManager] No content found for chapter: ${chapterId}`)
     return ''
   }
 
@@ -282,32 +263,21 @@ class StorageManager {
     const chapter = await this.getChapter(bookId, chapterId)
     if (!chapter) throw new Error(`Chapter not found: ${chapterId}`)
 
-    console.log(`[StorageManager] Saving content for chapter: ${chapterId}`, {
-      length: content.length,
-      path: chapter.path,
-    })
-
     // Store content directly in chapter object
     chapter.content = content
     chapter.updatedAt = new Date().toISOString()
 
-    try {
-      await this._writeToStore(STORAGE_CONFIG.chapterStore, {
-        path: chapter.path,
-        data: chapter,
-      })
-      console.log(`[StorageManager] Chapter saved successfully: ${chapterId}`)
-    } catch (err) {
-      console.error(`[StorageManager] Failed to save chapter: ${chapterId}`, err)
-      throw err
-    }
+    await this._writeToStore(STORAGE_CONFIG.chapterStore, {
+      path: chapter.path,
+      data: chapter,
+    })
 
     // Try to also save to files store (optional)
     try {
       const notesPath = `${chapter.path}/Notes.md`
       await this._writeFile(notesPath, content)
     } catch (err) {
-      console.warn(`[StorageManager] Failed to save to files store (non-critical):`, err)
+      // Non-critical, silently fail
     }
   }
 


### PR DESCRIPTION
Removed:
- All console.log statements from StorageManager
- Logging was cluttering output (persistence was working)

Added:
- Image icon import from lucide-react
- Image upload button in WikiEditor toolbar
- File input for image selection
- FileReader to convert images to base64
- Images embedded as inline HTML with max-width styling
- Auto-reset of file input after selection

Users can now:
- Click image button in editor toolbar
- Select image from disk
- Image automatically inserted with proper sizing
- Images displayed inline in editor and preview