### PR TITLE
Add image paste support and improve image handling

### DIFF
--- a/src/components/WikiEditor.jsx
+++ b/src/components/WikiEditor.jsx
@@ -215,6 +215,31 @@ export default function WikiEditor({ value = '', onChange, placeholder = 'Start 
         }
         return false
       },
+      handlePaste(view, event) {
+        // Handle image paste
+        if (!readOnly) {
+          const items = event.clipboardData?.items
+          if (items) {
+            for (const item of items) {
+              if (item.type.startsWith('image/')) {
+                const file = item.getAsFile()
+                if (file) {
+                  const reader = new FileReader()
+                  reader.onload = (ev) => {
+                    const dataUrl = ev.target?.result
+                    if (dataUrl && editor?.isActive) {
+                      editor.chain().focus().insertContent(`<img src="${dataUrl}" style="max-width: 100%; height: auto;" alt="Pasted image" />`).run()
+                    }
+                  }
+                  reader.readAsDataURL(file)
+                  return true
+                }
+              }
+            }
+          }
+        }
+        return false
+      },
     },
     onUpdate({ editor }) {
       // Flag this as an internal change so the useEffect below won't reset cursor


### PR DESCRIPTION
Features:
- Users can now paste images directly into editor
- handlePaste event added to editorProps
- Automatically detects image/ MIME types from clipboard
- Converts to base64 and inserts as inline image
- Image button still available in toolbar

How to use:
- PASTE: Cmd+V or Ctrl+V with image in clipboard
- UPLOAD: Click image button in toolbar, select file
- Both methods convert to base64 and embed inline

Note: Image button only visible in EDIT mode
Make sure to click the Edit button first to see toolbar