### PR TITLE
Fix image display - preserve base64 data URLs in markdown conversion

### DIFF
--- a/src/components/WikiEditor.jsx
+++ b/src/components/WikiEditor.jsx
@@ -29,6 +29,18 @@ const td = new TurndownService({
 })
 td.use(gfm)
 
+// Keep img tags as HTML to preserve base64 data URLs
+td.addRule('img', {
+  filter: 'img',
+  replacement: (content, node) => {
+    const src = node.getAttribute('src') || ''
+    const alt = node.getAttribute('alt') || 'image'
+    const style = node.getAttribute('style') || 'max-width: 100%; height: auto;'
+    // Return as HTML to preserve data URLs
+    return `<img src="${src}" alt="${alt}" style="${style}" />`
+  }
+})
+
 function markdownToHtml(md) {
   if (!md) return ''
   return marked.parse(md)


### PR DESCRIPTION
Problem:
- Images inserted as <img src="data:image/..." />
- TurndownService converted to markdown ![alt](url)
- marked converted back, but base64 URLs were lost
- Images appeared as broken

Solution:
- Add custom img rule to TurndownService
- Keep img tags as HTML instead of converting to markdown
- Preserves full src attribute including base64 data URLs
- Images now display correctly when markdown is parsed back

Result:
- Paste images: Works ✓
- Upload images: Works ✓
- Images persist on save/reload: Works ✓