### PR TITLE
Fix: Remove BooksManagement imports from Settings

### DIFF
--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -31,8 +31,6 @@ import {
 import * as LucideIcons from 'lucide-react'
 import useAppStore from '../store/useAppStore.js'
 import { ICON_OPTIONS } from '../constants/ui.js'
-import BooksManagement from '../components/BooksManagement.jsx'
-import '../styles/books-management.css'
 
 // ── Shared helpers ─────────────────────────────────────────────────────────────
 
@@ -753,11 +751,6 @@ export default function Settings() {
           </button>
         </div>
       </section>
-
-      <div className="divider" />
-
-      {/* ── Books Management ──────────────────────────────── */}
-      <BooksManagement />
 
       <div className="divider" />
 


### PR DESCRIPTION
- Removed unused BooksManagement component import
- Removed associated books-management.css import
- Removed BooksManagement component from settings UI

https://claude.ai/code/session_01XSMGsfLhJ6yua4mXqLoGjB