### PR TITLE
Fix markdown preview text visibility in wiki editor

### DIFF
--- a/src/pages/WikiPage.jsx
+++ b/src/pages/WikiPage.jsx
@@ -231,12 +231,8 @@ export default function WikiPage() {
                   hideToolbar={!isEditing}
                   visibleDragbar={false}
                   height={isEditing ? 600 : 'auto'}
-                  className="wiki-md-editor"
-                  textareaProps={{
-                    placeholder: 'Write your documentation here...',
-                  }}
-                  visibleDragbar={false}
                   enableScroll={true}
+                  className="wiki-md-editor"
                   textareaProps={{
                     disabled: !isEditing,
                     placeholder: 'Write your documentation here...',

--- a/src/styles/wiki-page.css
+++ b/src/styles/wiki-page.css
@@ -260,6 +260,24 @@
   color: var(--color-text) !important;
 }
 
+/* Ensure all text is visible in preview mode */
+.wiki-md-editor .md-editor-preview * {
+  color: var(--color-text) !important;
+}
+
+/* Reset specific element colors that might override */
+.wiki-md-editor .md-editor-preview p { color: var(--color-text) !important; }
+.wiki-md-editor .md-editor-preview h1 { color: var(--color-text) !important; }
+.wiki-md-editor .md-editor-preview h2 { color: var(--color-text) !important; }
+.wiki-md-editor .md-editor-preview h3 { color: var(--color-text) !important; }
+.wiki-md-editor .md-editor-preview h4 { color: var(--color-text) !important; }
+.wiki-md-editor .md-editor-preview h5 { color: var(--color-text) !important; }
+.wiki-md-editor .md-editor-preview h6 { color: var(--color-text) !important; }
+.wiki-md-editor .md-editor-preview li { color: var(--color-text) !important; }
+.wiki-md-editor .md-editor-preview blockquote { color: var(--color-text-muted) !important; }
+.wiki-md-editor .md-editor-preview code { color: var(--color-secondary) !important; }
+.wiki-md-editor .md-editor-preview a { color: var(--color-primary) !important; }
+
 .wiki-md-editor .md-editor-toolbar {
   background-color: var(--color-sidebar) !important;
   border-bottom: 1px solid var(--color-border) !important;

--- a/src/styles/wiki-page.css
+++ b/src/styles/wiki-page.css
@@ -207,6 +207,27 @@
   color: var(--color-text) !important;
 }
 
+/* MDEditor markdown preview content */
+.wiki-md-editor .markdown {
+  color: var(--color-text) !important;
+}
+
+.wiki-md-editor .markdown p,
+.wiki-md-editor .markdown li,
+.wiki-md-editor .markdown span,
+.wiki-md-editor .markdown div {
+  color: var(--color-text) !important;
+}
+
+.wiki-md-editor .markdown h1,
+.wiki-md-editor .markdown h2,
+.wiki-md-editor .markdown h3,
+.wiki-md-editor .markdown h4,
+.wiki-md-editor .markdown h5,
+.wiki-md-editor .markdown h6 {
+  color: var(--color-text) !important;
+}
+
 .wiki-md-editor textarea,
 .wiki-md-editor input {
   background-color: var(--color-surface) !important;
@@ -220,6 +241,23 @@
 .wiki-md-editor textarea::placeholder {
   color: var(--color-text-muted) !important;
   opacity: 1 !important;
+}
+
+/* Additional markdown preview styling for visibility */
+.wiki-md-editor .markdown-body {
+  color: var(--color-text) !important;
+  background-color: transparent;
+}
+
+.wiki-md-editor .markdown-body p,
+.wiki-md-editor .markdown-body li,
+.wiki-md-editor .markdown-body dd,
+.wiki-md-editor .markdown-body dt {
+  color: var(--color-text) !important;
+}
+
+.wiki-md-editor [class*="markdown"] {
+  color: var(--color-text) !important;
 }
 
 .wiki-md-editor .md-editor-toolbar {


### PR DESCRIPTION
## Summary
This PR improves the visibility of markdown preview content in the wiki editor by adding comprehensive CSS styling to ensure all text elements use the correct theme colors.

## Key Changes
- **CSS Styling**: Added extensive CSS rules to the wiki page stylesheet to ensure markdown preview content respects the theme's text color variable (`--color-text`)
  - Styled base markdown containers (`.markdown`, `.markdown-body`)
  - Styled all text elements (paragraphs, lists, headings, spans, divs)
  - Styled preview-specific containers (`.md-editor-preview`)
  - Added semantic color styling for special elements (blockquotes, code, links)
  
- **Code Cleanup**: Fixed duplicate `visibleDragbar` prop in WikiPage.jsx MDEditor component and reordered props for better readability

## Implementation Details
The changes target multiple CSS selectors to handle different markdown editor implementations:
- `.markdown` and `.markdown-body` classes for general markdown content
- `.md-editor-preview` class for preview mode specific styling
- Wildcard selector `[class*="markdown"]` to catch any markdown-related classes
- Specific element selectors with `!important` flags to override any conflicting styles

Special semantic colors are applied to:
- Blockquotes: `--color-text-muted`
- Code blocks: `--color-secondary`
- Links: `--color-primary`

This ensures the markdown preview is readable in all theme modes while maintaining visual hierarchy.

https://claude.ai/code/session_017SGxMmcZwP4c6t1jyaRLe7